### PR TITLE
ODP-1095 Critical CVE fixes patch

### DIFF
--- a/gateway-adapter/pom.xml
+++ b/gateway-adapter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-adapter</artifactId>

--- a/gateway-adapter/pom.xml
+++ b/gateway-adapter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-adapter</artifactId>

--- a/gateway-adapter/pom.xml
+++ b/gateway-adapter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-adapter</artifactId>

--- a/gateway-admin-ui/pom.xml
+++ b/gateway-admin-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-admin-ui</artifactId>

--- a/gateway-admin-ui/pom.xml
+++ b/gateway-admin-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-admin-ui</artifactId>

--- a/gateway-admin-ui/pom.xml
+++ b/gateway-admin-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-admin-ui</artifactId>

--- a/gateway-applications/pom.xml
+++ b/gateway-applications/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-applications</artifactId>

--- a/gateway-applications/pom.xml
+++ b/gateway-applications/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-applications</artifactId>

--- a/gateway-applications/pom.xml
+++ b/gateway-applications/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-applications</artifactId>

--- a/gateway-demo-ldap-launcher/pom.xml
+++ b/gateway-demo-ldap-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-demo-ldap-launcher</artifactId>
     <name>gateway-demo-ldap-launcher</name>

--- a/gateway-demo-ldap-launcher/pom.xml
+++ b/gateway-demo-ldap-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-demo-ldap-launcher</artifactId>
     <name>gateway-demo-ldap-launcher</name>

--- a/gateway-demo-ldap-launcher/pom.xml
+++ b/gateway-demo-ldap-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-demo-ldap-launcher</artifactId>
     <name>gateway-demo-ldap-launcher</name>

--- a/gateway-demo-ldap/pom.xml
+++ b/gateway-demo-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-demo-ldap</artifactId>

--- a/gateway-demo-ldap/pom.xml
+++ b/gateway-demo-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-demo-ldap</artifactId>

--- a/gateway-demo-ldap/pom.xml
+++ b/gateway-demo-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-demo-ldap</artifactId>

--- a/gateway-discovery-ambari/pom.xml
+++ b/gateway-discovery-ambari/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-discovery-ambari</artifactId>

--- a/gateway-discovery-ambari/pom.xml
+++ b/gateway-discovery-ambari/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-discovery-ambari</artifactId>

--- a/gateway-discovery-ambari/pom.xml
+++ b/gateway-discovery-ambari/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-discovery-ambari</artifactId>

--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-docker</artifactId>
 

--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-docker</artifactId>
 

--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-docker</artifactId>
 

--- a/gateway-i18n-logging-log4j/pom.xml
+++ b/gateway-i18n-logging-log4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-log4j</artifactId>

--- a/gateway-i18n-logging-log4j/pom.xml
+++ b/gateway-i18n-logging-log4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-log4j</artifactId>

--- a/gateway-i18n-logging-log4j/pom.xml
+++ b/gateway-i18n-logging-log4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-log4j</artifactId>

--- a/gateway-i18n-logging-sl4j/pom.xml
+++ b/gateway-i18n-logging-sl4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-sl4j</artifactId>

--- a/gateway-i18n-logging-sl4j/pom.xml
+++ b/gateway-i18n-logging-sl4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-sl4j</artifactId>

--- a/gateway-i18n-logging-sl4j/pom.xml
+++ b/gateway-i18n-logging-sl4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-sl4j</artifactId>

--- a/gateway-i18n/pom.xml
+++ b/gateway-i18n/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-i18n</artifactId>

--- a/gateway-i18n/pom.xml
+++ b/gateway-i18n/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-i18n</artifactId>

--- a/gateway-i18n/pom.xml
+++ b/gateway-i18n/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-i18n</artifactId>

--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-openapi-ui</artifactId>

--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-openapi-ui</artifactId>

--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-openapi-ui</artifactId>

--- a/gateway-performance-test/pom.xml
+++ b/gateway-performance-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-performance-test</artifactId>

--- a/gateway-performance-test/pom.xml
+++ b/gateway-performance-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-performance-test</artifactId>

--- a/gateway-performance-test/pom.xml
+++ b/gateway-performance-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-performance-test</artifactId>

--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-ha</artifactId>

--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-ha</artifactId>

--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-ha</artifactId>

--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-common</artifactId>

--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-common</artifactId>

--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-common</artifactId>

--- a/gateway-provider-identity-assertion-concat/pom.xml
+++ b/gateway-provider-identity-assertion-concat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-concat</artifactId>

--- a/gateway-provider-identity-assertion-concat/pom.xml
+++ b/gateway-provider-identity-assertion-concat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-concat</artifactId>

--- a/gateway-provider-identity-assertion-concat/pom.xml
+++ b/gateway-provider-identity-assertion-concat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-concat</artifactId>

--- a/gateway-provider-identity-assertion-hadoop-groups/pom.xml
+++ b/gateway-provider-identity-assertion-hadoop-groups/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-hadoop-groups</artifactId>

--- a/gateway-provider-identity-assertion-hadoop-groups/pom.xml
+++ b/gateway-provider-identity-assertion-hadoop-groups/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-hadoop-groups</artifactId>

--- a/gateway-provider-identity-assertion-hadoop-groups/pom.xml
+++ b/gateway-provider-identity-assertion-hadoop-groups/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-hadoop-groups</artifactId>

--- a/gateway-provider-identity-assertion-pseudo/pom.xml
+++ b/gateway-provider-identity-assertion-pseudo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-pseudo</artifactId>

--- a/gateway-provider-identity-assertion-pseudo/pom.xml
+++ b/gateway-provider-identity-assertion-pseudo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-pseudo</artifactId>

--- a/gateway-provider-identity-assertion-pseudo/pom.xml
+++ b/gateway-provider-identity-assertion-pseudo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-pseudo</artifactId>

--- a/gateway-provider-identity-assertion-regex/pom.xml
+++ b/gateway-provider-identity-assertion-regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-regex</artifactId>

--- a/gateway-provider-identity-assertion-regex/pom.xml
+++ b/gateway-provider-identity-assertion-regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-regex</artifactId>

--- a/gateway-provider-identity-assertion-regex/pom.xml
+++ b/gateway-provider-identity-assertion-regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-regex</artifactId>

--- a/gateway-provider-identity-assertion-switchcase/pom.xml
+++ b/gateway-provider-identity-assertion-switchcase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-switchcase</artifactId>

--- a/gateway-provider-identity-assertion-switchcase/pom.xml
+++ b/gateway-provider-identity-assertion-switchcase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-switchcase</artifactId>

--- a/gateway-provider-identity-assertion-switchcase/pom.xml
+++ b/gateway-provider-identity-assertion-switchcase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-switchcase</artifactId>

--- a/gateway-provider-jersey/pom.xml
+++ b/gateway-provider-jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-jersey</artifactId>

--- a/gateway-provider-jersey/pom.xml
+++ b/gateway-provider-jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-jersey</artifactId>

--- a/gateway-provider-jersey/pom.xml
+++ b/gateway-provider-jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-jersey</artifactId>

--- a/gateway-provider-rewrite-common/pom.xml
+++ b/gateway-provider-rewrite-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-common</artifactId>

--- a/gateway-provider-rewrite-common/pom.xml
+++ b/gateway-provider-rewrite-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-common</artifactId>

--- a/gateway-provider-rewrite-common/pom.xml
+++ b/gateway-provider-rewrite-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-common</artifactId>

--- a/gateway-provider-rewrite-func-hostmap-static/pom.xml
+++ b/gateway-provider-rewrite-func-hostmap-static/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-provider-rewrite-func-hostmap-static</artifactId>

--- a/gateway-provider-rewrite-func-hostmap-static/pom.xml
+++ b/gateway-provider-rewrite-func-hostmap-static/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-provider-rewrite-func-hostmap-static</artifactId>

--- a/gateway-provider-rewrite-func-hostmap-static/pom.xml
+++ b/gateway-provider-rewrite-func-hostmap-static/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-provider-rewrite-func-hostmap-static</artifactId>

--- a/gateway-provider-rewrite-func-inbound-query-param/pom.xml
+++ b/gateway-provider-rewrite-func-inbound-query-param/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-provider-rewrite-func-inbound-query-param</artifactId>
     <name>gateway-provider-rewrite-func-inbound-url</name>

--- a/gateway-provider-rewrite-func-inbound-query-param/pom.xml
+++ b/gateway-provider-rewrite-func-inbound-query-param/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-provider-rewrite-func-inbound-query-param</artifactId>
     <name>gateway-provider-rewrite-func-inbound-url</name>

--- a/gateway-provider-rewrite-func-inbound-query-param/pom.xml
+++ b/gateway-provider-rewrite-func-inbound-query-param/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-rewrite-func-inbound-query-param</artifactId>
     <name>gateway-provider-rewrite-func-inbound-url</name>

--- a/gateway-provider-rewrite-func-service-registry/pom.xml
+++ b/gateway-provider-rewrite-func-service-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-func-service-registry</artifactId>

--- a/gateway-provider-rewrite-func-service-registry/pom.xml
+++ b/gateway-provider-rewrite-func-service-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-func-service-registry</artifactId>

--- a/gateway-provider-rewrite-func-service-registry/pom.xml
+++ b/gateway-provider-rewrite-func-service-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-func-service-registry</artifactId>

--- a/gateway-provider-rewrite-step-encrypt-uri/pom.xml
+++ b/gateway-provider-rewrite-step-encrypt-uri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-encrypt-uri</artifactId>

--- a/gateway-provider-rewrite-step-encrypt-uri/pom.xml
+++ b/gateway-provider-rewrite-step-encrypt-uri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-encrypt-uri</artifactId>

--- a/gateway-provider-rewrite-step-encrypt-uri/pom.xml
+++ b/gateway-provider-rewrite-step-encrypt-uri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-encrypt-uri</artifactId>

--- a/gateway-provider-rewrite-step-secure-query/pom.xml
+++ b/gateway-provider-rewrite-step-secure-query/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-secure-query</artifactId>

--- a/gateway-provider-rewrite-step-secure-query/pom.xml
+++ b/gateway-provider-rewrite-step-secure-query/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-secure-query</artifactId>

--- a/gateway-provider-rewrite-step-secure-query/pom.xml
+++ b/gateway-provider-rewrite-step-secure-query/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-secure-query</artifactId>

--- a/gateway-provider-rewrite/pom.xml
+++ b/gateway-provider-rewrite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite</artifactId>

--- a/gateway-provider-rewrite/pom.xml
+++ b/gateway-provider-rewrite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite</artifactId>

--- a/gateway-provider-rewrite/pom.xml
+++ b/gateway-provider-rewrite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite</artifactId>

--- a/gateway-provider-security-authc-anon/pom.xml
+++ b/gateway-provider-security-authc-anon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-authc-anon</artifactId>

--- a/gateway-provider-security-authc-anon/pom.xml
+++ b/gateway-provider-security-authc-anon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-authc-anon</artifactId>

--- a/gateway-provider-security-authc-anon/pom.xml
+++ b/gateway-provider-security-authc-anon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-authc-anon</artifactId>

--- a/gateway-provider-security-authz-acls/pom.xml
+++ b/gateway-provider-security-authz-acls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-provider-security-authz-acls</artifactId>
     <name>gateway-provider-security-authz-acls</name>

--- a/gateway-provider-security-authz-acls/pom.xml
+++ b/gateway-provider-security-authz-acls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-security-authz-acls</artifactId>
     <name>gateway-provider-security-authz-acls</name>

--- a/gateway-provider-security-authz-acls/pom.xml
+++ b/gateway-provider-security-authz-acls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-provider-security-authz-acls</artifactId>
     <name>gateway-provider-security-authz-acls</name>

--- a/gateway-provider-security-authz-composite/pom.xml
+++ b/gateway-provider-security-authz-composite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-security-authz-composite</artifactId>
     <name>gateway-provider-security-authz-composite</name>

--- a/gateway-provider-security-authz-composite/pom.xml
+++ b/gateway-provider-security-authz-composite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-provider-security-authz-composite</artifactId>
     <name>gateway-provider-security-authz-composite</name>

--- a/gateway-provider-security-authz-composite/pom.xml
+++ b/gateway-provider-security-authz-composite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-provider-security-authz-composite</artifactId>
     <name>gateway-provider-security-authz-composite</name>

--- a/gateway-provider-security-clientcert/pom.xml
+++ b/gateway-provider-security-clientcert/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-clientcert</artifactId>

--- a/gateway-provider-security-clientcert/pom.xml
+++ b/gateway-provider-security-clientcert/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-clientcert</artifactId>

--- a/gateway-provider-security-clientcert/pom.xml
+++ b/gateway-provider-security-clientcert/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-clientcert</artifactId>

--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-provider-security-hadoopauth</artifactId>

--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-provider-security-hadoopauth</artifactId>

--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-provider-security-hadoopauth</artifactId>

--- a/gateway-provider-security-jwt/pom.xml
+++ b/gateway-provider-security-jwt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-jwt</artifactId>

--- a/gateway-provider-security-jwt/pom.xml
+++ b/gateway-provider-security-jwt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-jwt</artifactId>

--- a/gateway-provider-security-jwt/pom.xml
+++ b/gateway-provider-security-jwt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-jwt</artifactId>

--- a/gateway-provider-security-pac4j/pom.xml
+++ b/gateway-provider-security-pac4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-pac4j</artifactId>

--- a/gateway-provider-security-pac4j/pom.xml
+++ b/gateway-provider-security-pac4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-pac4j</artifactId>

--- a/gateway-provider-security-pac4j/pom.xml
+++ b/gateway-provider-security-pac4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-pac4j</artifactId>

--- a/gateway-provider-security-preauth/pom.xml
+++ b/gateway-provider-security-preauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-preauth</artifactId>

--- a/gateway-provider-security-preauth/pom.xml
+++ b/gateway-provider-security-preauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-preauth</artifactId>

--- a/gateway-provider-security-preauth/pom.xml
+++ b/gateway-provider-security-preauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-preauth</artifactId>

--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-shiro</artifactId>

--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-shiro</artifactId>

--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-shiro</artifactId>

--- a/gateway-provider-security-webappsec/pom.xml
+++ b/gateway-provider-security-webappsec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-provider-security-webappsec</artifactId>

--- a/gateway-provider-security-webappsec/pom.xml
+++ b/gateway-provider-security-webappsec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-provider-security-webappsec</artifactId>

--- a/gateway-provider-security-webappsec/pom.xml
+++ b/gateway-provider-security-webappsec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-webappsec</artifactId>

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gateway-release-common</artifactId>

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
   </parent>
 
   <artifactId>gateway-release-common</artifactId>

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
   </parent>
 
   <artifactId>gateway-release-common</artifactId>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-release</artifactId>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-release</artifactId>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-release</artifactId>

--- a/gateway-server-launcher/pom.xml
+++ b/gateway-server-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-server-launcher</artifactId>

--- a/gateway-server-launcher/pom.xml
+++ b/gateway-server-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server-launcher</artifactId>

--- a/gateway-server-launcher/pom.xml
+++ b/gateway-server-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-server-launcher</artifactId>

--- a/gateway-server-xforwarded-filter/pom.xml
+++ b/gateway-server-xforwarded-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-server-xforwarded-filter</artifactId>

--- a/gateway-server-xforwarded-filter/pom.xml
+++ b/gateway-server-xforwarded-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server-xforwarded-filter</artifactId>

--- a/gateway-server-xforwarded-filter/pom.xml
+++ b/gateway-server-xforwarded-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-server-xforwarded-filter</artifactId>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-server</artifactId>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-server</artifactId>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server</artifactId>

--- a/gateway-service-admin/pom.xml
+++ b/gateway-service-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-admin</artifactId>

--- a/gateway-service-admin/pom.xml
+++ b/gateway-service-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-admin</artifactId>

--- a/gateway-service-admin/pom.xml
+++ b/gateway-service-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-admin</artifactId>

--- a/gateway-service-as/pom.xml
+++ b/gateway-service-as/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-service-as</artifactId>
 

--- a/gateway-service-as/pom.xml
+++ b/gateway-service-as/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-service-as</artifactId>
 

--- a/gateway-service-as/pom.xml
+++ b/gateway-service-as/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-service-as</artifactId>
 

--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-definitions</artifactId>

--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-definitions</artifactId>

--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-definitions</artifactId>

--- a/gateway-service-hashicorp-vault/pom.xml
+++ b/gateway-service-hashicorp-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-hashicorp-vault</artifactId>

--- a/gateway-service-hashicorp-vault/pom.xml
+++ b/gateway-service-hashicorp-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-hashicorp-vault</artifactId>

--- a/gateway-service-hashicorp-vault/pom.xml
+++ b/gateway-service-hashicorp-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hashicorp-vault</artifactId>

--- a/gateway-service-hbase/pom.xml
+++ b/gateway-service-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-hbase</artifactId>

--- a/gateway-service-hbase/pom.xml
+++ b/gateway-service-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-hbase</artifactId>

--- a/gateway-service-hbase/pom.xml
+++ b/gateway-service-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hbase</artifactId>

--- a/gateway-service-health/pom.xml
+++ b/gateway-service-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-health</artifactId>

--- a/gateway-service-health/pom.xml
+++ b/gateway-service-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-health</artifactId>

--- a/gateway-service-health/pom.xml
+++ b/gateway-service-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-health</artifactId>

--- a/gateway-service-hive/pom.xml
+++ b/gateway-service-hive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-hive</artifactId>

--- a/gateway-service-hive/pom.xml
+++ b/gateway-service-hive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hive</artifactId>

--- a/gateway-service-hive/pom.xml
+++ b/gateway-service-hive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-hive</artifactId>

--- a/gateway-service-impala/pom.xml
+++ b/gateway-service-impala/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-impala</artifactId>

--- a/gateway-service-impala/pom.xml
+++ b/gateway-service-impala/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-impala</artifactId>

--- a/gateway-service-impala/pom.xml
+++ b/gateway-service-impala/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-impala</artifactId>

--- a/gateway-service-jkg/pom.xml
+++ b/gateway-service-jkg/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-jkg</artifactId>

--- a/gateway-service-jkg/pom.xml
+++ b/gateway-service-jkg/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-jkg</artifactId>

--- a/gateway-service-jkg/pom.xml
+++ b/gateway-service-jkg/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-jkg</artifactId>

--- a/gateway-service-knoxsso/pom.xml
+++ b/gateway-service-knoxsso/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-knoxsso</artifactId>

--- a/gateway-service-knoxsso/pom.xml
+++ b/gateway-service-knoxsso/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-knoxsso</artifactId>

--- a/gateway-service-knoxsso/pom.xml
+++ b/gateway-service-knoxsso/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-knoxsso</artifactId>

--- a/gateway-service-knoxssout/pom.xml
+++ b/gateway-service-knoxssout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-service-knoxssout</artifactId>

--- a/gateway-service-knoxssout/pom.xml
+++ b/gateway-service-knoxssout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-service-knoxssout</artifactId>

--- a/gateway-service-knoxssout/pom.xml
+++ b/gateway-service-knoxssout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-service-knoxssout</artifactId>

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-knoxtoken</artifactId>

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-knoxtoken</artifactId>

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-knoxtoken</artifactId>

--- a/gateway-service-livy/pom.xml
+++ b/gateway-service-livy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-livy</artifactId>

--- a/gateway-service-livy/pom.xml
+++ b/gateway-service-livy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-livy</artifactId>

--- a/gateway-service-livy/pom.xml
+++ b/gateway-service-livy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-livy</artifactId>

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-metadata</artifactId>

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-metadata</artifactId>

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-metadata</artifactId>

--- a/gateway-service-nifi-registry/pom.xml
+++ b/gateway-service-nifi-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-nifi-registry</artifactId>

--- a/gateway-service-nifi-registry/pom.xml
+++ b/gateway-service-nifi-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-nifi-registry</artifactId>

--- a/gateway-service-nifi-registry/pom.xml
+++ b/gateway-service-nifi-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-nifi-registry</artifactId>

--- a/gateway-service-nifi/pom.xml
+++ b/gateway-service-nifi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-nifi</artifactId>

--- a/gateway-service-nifi/pom.xml
+++ b/gateway-service-nifi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-nifi</artifactId>

--- a/gateway-service-nifi/pom.xml
+++ b/gateway-service-nifi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-nifi</artifactId>

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-remoteconfig</artifactId>

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-remoteconfig</artifactId>

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-remoteconfig</artifactId>

--- a/gateway-service-rm/pom.xml
+++ b/gateway-service-rm/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-rm</artifactId>

--- a/gateway-service-rm/pom.xml
+++ b/gateway-service-rm/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-rm</artifactId>

--- a/gateway-service-rm/pom.xml
+++ b/gateway-service-rm/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-rm</artifactId>

--- a/gateway-service-session/pom.xml
+++ b/gateway-service-session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-session</artifactId>

--- a/gateway-service-session/pom.xml
+++ b/gateway-service-session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-session</artifactId>

--- a/gateway-service-session/pom.xml
+++ b/gateway-service-session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-session</artifactId>

--- a/gateway-service-storm/pom.xml
+++ b/gateway-service-storm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-storm</artifactId>

--- a/gateway-service-storm/pom.xml
+++ b/gateway-service-storm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-storm</artifactId>

--- a/gateway-service-storm/pom.xml
+++ b/gateway-service-storm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-storm</artifactId>

--- a/gateway-service-test/pom.xml
+++ b/gateway-service-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-test</artifactId>

--- a/gateway-service-test/pom.xml
+++ b/gateway-service-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-test</artifactId>

--- a/gateway-service-test/pom.xml
+++ b/gateway-service-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-test</artifactId>

--- a/gateway-service-tgs/pom.xml
+++ b/gateway-service-tgs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-tgs</artifactId>

--- a/gateway-service-tgs/pom.xml
+++ b/gateway-service-tgs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-tgs</artifactId>

--- a/gateway-service-tgs/pom.xml
+++ b/gateway-service-tgs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-tgs</artifactId>

--- a/gateway-service-vault/pom.xml
+++ b/gateway-service-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-service-vault</artifactId>

--- a/gateway-service-vault/pom.xml
+++ b/gateway-service-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-service-vault</artifactId>

--- a/gateway-service-vault/pom.xml
+++ b/gateway-service-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-service-vault</artifactId>

--- a/gateway-service-webhdfs/pom.xml
+++ b/gateway-service-webhdfs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-service-webhdfs</artifactId>

--- a/gateway-service-webhdfs/pom.xml
+++ b/gateway-service-webhdfs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-webhdfs</artifactId>

--- a/gateway-service-webhdfs/pom.xml
+++ b/gateway-service-webhdfs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-service-webhdfs</artifactId>

--- a/gateway-shell-launcher/pom.xml
+++ b/gateway-shell-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-shell-launcher</artifactId>

--- a/gateway-shell-launcher/pom.xml
+++ b/gateway-shell-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-shell-launcher</artifactId>

--- a/gateway-shell-launcher/pom.xml
+++ b/gateway-shell-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-launcher</artifactId>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-shell-release</artifactId>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-release</artifactId>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-shell-release</artifactId>

--- a/gateway-shell-samples/pom.xml
+++ b/gateway-shell-samples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-shell-samples</artifactId>

--- a/gateway-shell-samples/pom.xml
+++ b/gateway-shell-samples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-samples</artifactId>

--- a/gateway-shell-samples/pom.xml
+++ b/gateway-shell-samples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-shell-samples</artifactId>

--- a/gateway-shell/pom.xml
+++ b/gateway-shell/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-shell</artifactId>

--- a/gateway-shell/pom.xml
+++ b/gateway-shell/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell</artifactId>

--- a/gateway-shell/pom.xml
+++ b/gateway-shell/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-shell</artifactId>

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-spi</artifactId>

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-spi</artifactId>

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-spi</artifactId>

--- a/gateway-test-release-utils/pom.xml
+++ b/gateway-test-release-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-test-release-utils/pom.xml
+++ b/gateway-test-release-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-test-release-utils/pom.xml
+++ b/gateway-test-release-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <hadoop-jersey.version>1.19</hadoop-jersey.version>
+        <hadoop-jersey.version>1.19.4</hadoop-jersey.version>
     </properties>
 
     <dependencies>

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test-release</artifactId>

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-test-release</artifactId>

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-test-release</artifactId>

--- a/gateway-test-release/webhdfs-kerb-test/pom.xml
+++ b/gateway-test-release/webhdfs-kerb-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>webhdfs-kerb-test</artifactId>

--- a/gateway-test-release/webhdfs-kerb-test/pom.xml
+++ b/gateway-test-release/webhdfs-kerb-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>webhdfs-kerb-test</artifactId>

--- a/gateway-test-release/webhdfs-kerb-test/pom.xml
+++ b/gateway-test-release/webhdfs-kerb-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webhdfs-kerb-test</artifactId>

--- a/gateway-test-release/webhdfs-test/pom.xml
+++ b/gateway-test-release/webhdfs-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>webhdfs-test</artifactId>

--- a/gateway-test-release/webhdfs-test/pom.xml
+++ b/gateway-test-release/webhdfs-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>webhdfs-test</artifactId>

--- a/gateway-test-release/webhdfs-test/pom.xml
+++ b/gateway-test-release/webhdfs-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webhdfs-test</artifactId>

--- a/gateway-test-utils/pom.xml
+++ b/gateway-test-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test-utils</artifactId>

--- a/gateway-test-utils/pom.xml
+++ b/gateway-test-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-test-utils</artifactId>

--- a/gateway-test-utils/pom.xml
+++ b/gateway-test-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-test-utils</artifactId>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test</artifactId>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-test</artifactId>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-test</artifactId>

--- a/gateway-topology-hadoop-xml/pom.xml
+++ b/gateway-topology-hadoop-xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-topology-hadoop-xml</artifactId>

--- a/gateway-topology-hadoop-xml/pom.xml
+++ b/gateway-topology-hadoop-xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-topology-hadoop-xml</artifactId>

--- a/gateway-topology-hadoop-xml/pom.xml
+++ b/gateway-topology-hadoop-xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-topology-hadoop-xml</artifactId>

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-topology-simple</artifactId>

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-topology-simple</artifactId>

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -66,9 +66,5 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-topology-simple</artifactId>

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     
     <artifactId>gateway-util-common</artifactId>

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-util-common</artifactId>

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     
     <artifactId>gateway-util-common</artifactId>

--- a/gateway-util-configinjector/pom.xml
+++ b/gateway-util-configinjector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-util-configinjector</artifactId>
 

--- a/gateway-util-configinjector/pom.xml
+++ b/gateway-util-configinjector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-util-configinjector</artifactId>
 

--- a/gateway-util-configinjector/pom.xml
+++ b/gateway-util-configinjector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-util-configinjector</artifactId>
 

--- a/gateway-util-launcher/pom.xml
+++ b/gateway-util-launcher/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-util-launcher</artifactId>
     <name>gateway-util-launcher</name>

--- a/gateway-util-launcher/pom.xml
+++ b/gateway-util-launcher/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
     <artifactId>gateway-util-launcher</artifactId>
     <name>gateway-util-launcher</name>

--- a/gateway-util-launcher/pom.xml
+++ b/gateway-util-launcher/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
     <artifactId>gateway-util-launcher</artifactId>
     <name>gateway-util-launcher</name>

--- a/gateway-util-urltemplate/pom.xml
+++ b/gateway-util-urltemplate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>gateway-util-urltemplate</artifactId>

--- a/gateway-util-urltemplate/pom.xml
+++ b/gateway-util-urltemplate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>gateway-util-urltemplate</artifactId>

--- a/gateway-util-urltemplate/pom.xml
+++ b/gateway-util-urltemplate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-util-urltemplate</artifactId>

--- a/hadoop-examples/pom.xml
+++ b/hadoop-examples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>hadoop-examples</artifactId>

--- a/hadoop-examples/pom.xml
+++ b/hadoop-examples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>hadoop-examples</artifactId>

--- a/hadoop-examples/pom.xml
+++ b/hadoop-examples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hadoop-examples</artifactId>

--- a/knox-cli-launcher/pom.xml
+++ b/knox-cli-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-cli-launcher</artifactId>

--- a/knox-cli-launcher/pom.xml
+++ b/knox-cli-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>knox-cli-launcher</artifactId>

--- a/knox-cli-launcher/pom.xml
+++ b/knox-cli-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>knox-cli-launcher</artifactId>

--- a/knox-homepage-ui/pom.xml
+++ b/knox-homepage-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>knox-homepage-ui</artifactId>

--- a/knox-homepage-ui/pom.xml
+++ b/knox-homepage-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>knox-homepage-ui</artifactId>

--- a/knox-homepage-ui/pom.xml
+++ b/knox-homepage-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-homepage-ui</artifactId>

--- a/knox-token-management-ui/pom.xml
+++ b/knox-token-management-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1095</version>
+        <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-token-management-ui</artifactId>

--- a/knox-token-management-ui/pom.xml
+++ b/knox-token-management-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+        <version>1.6.1.3.2.2.0-1</version>
     </parent>
 
     <artifactId>knox-token-management-ui</artifactId>

--- a/knox-token-management-ui/pom.xml
+++ b/knox-token-management-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.1.3.2.2.0-1</version>
+        <version>1.6.1.3.2.2.0-1095</version>
     </parent>
 
     <artifactId>knox-token-management-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.knox</groupId>
     <artifactId>gateway</artifactId>
-    <version>1.6.1.3.2.2.0-1095</version>
+    <version>1.6.1.3.3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>gateway</name>
@@ -215,7 +215,7 @@
         <gson.version>2.8.6</gson.version>
         <groovy.version>3.0.7</groovy.version>
         <guava.version>28.2-jre</guava.version>
-        <hadoop.version>3.2.3.3.2.2.0-1095</hadoop.version>
+        <hadoop.version>3.2.3.3.3.0.0-SNAPSHOT</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -288,7 +288,7 @@
         <xmltool.version>3.3</xmltool.version>
         <xml-jaxb.version>2.3.0</xml-jaxb.version>
         <xml-matchers.version>0.10</xml-matchers.version>
-        <zookeeper.version>3.5.10.3.2.2.0-1095</zookeeper.version>
+        <zookeeper.version>3.5.10.3.3.0.0-SNAPSHOT</zookeeper.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.knox</groupId>
     <artifactId>gateway</artifactId>
-    <version>1.6.1.3.2.2.0-1</version>
+    <version>1.6.1.3.2.2.0-1095</version>
     <packaging>pom</packaging>
 
     <name>gateway</name>
@@ -215,7 +215,7 @@
         <gson.version>2.8.6</gson.version>
         <groovy.version>3.0.7</groovy.version>
         <guava.version>28.2-jre</guava.version>
-        <hadoop.version>3.2.3.3.2.2.0-1</hadoop.version>
+        <hadoop.version>3.2.3.3.2.2.0-1095</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -288,7 +288,7 @@
         <xmltool.version>3.3</xmltool.version>
         <xml-jaxb.version>2.3.0</xml-jaxb.version>
         <xml-matchers.version>0.10</xml-matchers.version>
-        <zookeeper.version>3.5.10.3.2.2.0-1</zookeeper.version>
+        <zookeeper.version>3.5.10.3.2.2.0-1095</zookeeper.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.knox</groupId>
     <artifactId>gateway</artifactId>
-    <version>1.6.1.3.2.2.0-SNAPSHOT</version>
+    <version>1.6.1.3.2.2.0-1</version>
     <packaging>pom</packaging>
 
     <name>gateway</name>
@@ -215,7 +215,7 @@
         <gson.version>2.8.6</gson.version>
         <groovy.version>3.0.7</groovy.version>
         <guava.version>28.2-jre</guava.version>
-        <hadoop.version>3.2.3.3.2.2.0-SNAPSHOT</hadoop.version>
+        <hadoop.version>3.2.3.3.2.2.0-1</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -288,7 +288,7 @@
         <xmltool.version>3.3</xmltool.version>
         <xml-jaxb.version>2.3.0</xml-jaxb.version>
         <xml-matchers.version>0.10</xml-matchers.version>
-        <zookeeper.version>3.5.10.3.2.2.0-SNAPSHOT</zookeeper.version>
+        <zookeeper.version>3.5.10.3.2.2.0-1</zookeeper.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
This commit is to address all critical CVE fixes identified for current Hadoop version