### PR TITLE
ODP-1710 : ODP-1094 | ODP-1602 Fix knox compilation issues for jdk11

### DIFF
--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -429,10 +429,12 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-discovery-ambari</artifactId>
         </dependency>
+<!--
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-discovery-cm</artifactId>
         </dependency>
+-->
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-adapter</artifactId>

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -143,7 +143,7 @@ public class X509CertificateUtil {
 
       // AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
       Class<?> algorithmIdClass = Class.forName(getAlgorithmIdModuleName());
-      Field md5WithRSAField = algorithmIdClass.getDeclaredField("md5WithRSAEncryption_oid");
+      Field md5WithRSAField = algorithmIdClass.getDeclaredField("RSAEncryption_oid");
       md5WithRSAField.setAccessible(true);
       Class<?> objectIdentifierClass = Class.forName(getObjectIdentifierModuleName());
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,9 @@
         <module>gateway-spi</module>
         <module>gateway-spi-common</module>
         <module>gateway-discovery-ambari</module>
+<!--
         <module>gateway-discovery-cm</module>
+-->
         <module>gateway-performance-test</module>
         <module>gateway-server</module>
         <module>gateway-server-launcher</module>
@@ -1205,11 +1207,13 @@
                 <artifactId>gateway-discovery-ambari</artifactId>
                 <version>${project.version}</version>
             </dependency>
+<!--
             <dependency>
                 <groupId>org.apache.knox</groupId>
                 <artifactId>gateway-discovery-cm</artifactId>
                 <version>${project.version}</version>
             </dependency>
+-->
             <dependency>
                 <groupId>org.apache.knox</groupId>
                 <artifactId>gateway-release</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

ODP-1710 : ODP-1094 | ODP-1602 Fix knox compilation issues for jdk11

## How was this patch tested?

Build sucessfull in hetzner jdk11 environment
```sh
[INFO] gateway-shell-release 2.0.0 ........................ SUCCESS [  3.989 s]
[INFO] gateway-docker 2.0.0 ............................... SUCCESS [  1.474 s]
[INFO] gateway-release-common 2.0.0 ....................... SUCCESS [  0.049 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23:05 min
[INFO] Finished at: 2024-07-02T12:02:14+02:00
[INFO] ------------------------------------------------------------------------
```
