### PR TITLE
ODP-2966 Revert reload4j exclusion from hadoop jars in knox

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -109,22 +109,10 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.reload4j</groupId>
-                    <artifactId>reload4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.reload4j</groupId>
-                    <artifactId>reload4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
ODP-2966 Revert reload4j exclusion from hadoop jars in knox
This patch is tested in local clusters during ODP 3.2.3.3-3 testing.