### PR TITLE
ODP-3885 Include Ambari support for Service Discovery

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
@@ -328,7 +328,7 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
 
     @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
-      throw new UnsupportedOperationException("Filtering Ambari service discovery by service names is not supported!");
+        return discover(gwConfig, config, clusterName);
     }
 
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -73,7 +73,7 @@ public class SimpleDescriptorHandler {
      */
     public static final String RESULT_REFERENCE = "reference";
 
-    private static final String DEFAULT_DISCOVERY_TYPE = "ClouderaManager";
+    private static final String DEFAULT_DISCOVERY_TYPE = "Ambari";
 
     private static final String[] PROVIDER_CONFIG_FILE_EXTENSIONS;
     static {


### PR DESCRIPTION
As part of https://github.com/apache/knox/pull/533, Ambari Service Discovery has been unsupported. Using this patch to bring back support on top of Knox 2.0 with additional config changes updated in JIRA.

Tested on RHEL9 local lab, with ODP 3.3.6.1-1.