### PR TITLE
ODP-4999 - Ensure type=realtime/offline params forwarded correctly

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml
@@ -24,6 +24,7 @@
     <rule name="PINOT/inbound/ui-rootu" pattern="*://*:*/**/*/pinot">
         <rewrite template="{$serviceUrl[PINOT]}/"/>
     </rule>
+
     <!-- index.html -->
     <rule name="PINOT/inbound/ui-index" pattern="*://*:*/**/pinot/index.html">
         <rewrite template="{$serviceUrl[PINOT]}/index.html"/>
@@ -53,10 +54,23 @@
         <rewrite template="{$serviceUrl[PINOT]}/auth/info"/>
     </rule>
 
-    <!-- Pinot REST API Routes -->
+    <!-- CRITICAL FIX: Tables API - Query parameters MUST come before non-query rules -->
+    <!-- Tables with query parameters - HIGHER PRIORITY -->
+    <rule name="PINOT/api-tables-with-params" pattern="*://*:*/**/pinot/tables?{**}">
+        <rewrite template="{$serviceUrl[PINOT]}/tables?{**}"/>
+    </rule>
+
+    <!-- Tables sub-paths with query parameters - HIGHER PRIORITY -->
+    <rule name="PINOT/api-tables-sub-params" pattern="*://*:*/**/pinot/tables/{**}?{**}">
+        <rewrite template="{$serviceUrl[PINOT]}/tables/{**}?{**}"/>
+    </rule>
+
+    <!-- Tables root without parameters - LOWER PRIORITY -->
     <rule name="PINOT/api-tables-root" pattern="*://*:*/**/pinot/tables">
         <rewrite template="{$serviceUrl[PINOT]}/tables"/>
     </rule>
+
+    <!-- Tables sub-paths without parameters - LOWER PRIORITY -->
     <rule name="PINOT/api-tables-sub" pattern="*://*:*/**/pinot/tables/{**}">
         <rewrite template="{$serviceUrl[PINOT]}/tables/{**}"/>
     </rule>
@@ -69,13 +83,28 @@
         <rewrite template="{$serviceUrl[PINOT]}/cluster/{**}"/>
     </rule>
 
+    <!-- Schemas with query parameters -->
+    <rule name="PINOT/api-schemas-with-params" pattern="*://*:*/**/pinot/schemas?{**}">
+        <rewrite template="{$serviceUrl[PINOT]}/schemas?{**}"/>
+    </rule>
+
+    <rule name="PINOT/api-schemas" pattern="*://*:*/**/pinot/schemas">
+        <rewrite template="{$serviceUrl[PINOT]}/schemas"/>
+    </rule>
+
+    <rule name="PINOT/api-schemas-sub" pattern="*://*:*/**/pinot/schemas/{**}">
+        <rewrite template="{$serviceUrl[PINOT]}/schemas/{**}"/>
+    </rule>
+
     <!-- ZooKeeper API calls -->
     <rule name="PINOT/zk-ls-root" pattern="*://*:*/**/pinot/zk/ls">
         <rewrite template="{$serviceUrl[PINOT]}/zk/ls"/>
     </rule>
+
     <rule name="PINOT/zk-ls-sub" pattern="*://*:*/**/pinot/zk/ls/{**}">
         <rewrite template="{$serviceUrl[PINOT]}/zk/ls/{**}"/>
     </rule>
+
     <rule name="PINOT/zk-api" pattern="*://*:*/**/pinot/zk/ls?{path=**}?{**}">
         <rewrite template="{$serviceUrl[PINOT]}/zk/ls?{path=**}?{**}"/>
     </rule>
@@ -92,10 +121,6 @@
         <rewrite template="{$serviceUrl[PINOT]}/zk/stat?{path=**}"/>
     </rule>
 
-    <!-- Catch-all fallback -->
-    <rule name="PINOT/fallback" pattern="*://*:*/**/pinot/{**}">
-        <rewrite template="{$serviceUrl[PINOT]}/{**}"/>
-    </rule>
     <!-- Swagger UI Help Endpoint -->
     <rule name="PINOT/swagger-help" pattern="*://*:*/**/pinot/help">
         <rewrite template="{$serviceUrl[PINOT]}/help"/>
@@ -140,5 +165,9 @@
         <rewrite template="{$serviceUrl[PINOT]}/swaggerui-dist/swagger-ui-standalone-preset.js"/>
     </rule>
 
+    <!-- Catch-all fallback - MUST be last -->
+    <rule name="PINOT/fallback" pattern="*://*:*/**/pinot/{**}">
+        <rewrite template="{$serviceUrl[PINOT]}/{**}"/>
+    </rule>
 
 </rules>


### PR DESCRIPTION
Knox is receiving requests with ?type=realtime and ?type=offline parameters, but when it dispatches to Pinot, it's stripping the type parameter and only sending ?user.name=admin

What's Happening:
Pinot UI makes two separate calls:

GET /tables?type=realtime

GET /tables?type=offline

Knox receives both calls correctly but strips the type parameter

Knox sends identical requests to Pinot:

Both become: GET /tables?user.name=admin

Pinot returns the same response for both calls (all tables without type filtering)

Pinot UI gets duplicate data and displays "two test tables"