### PR TITLE
ODP-4672 : Upgrade com.fasterxml.jackson.core_jackson-databind to 2.16.1 for CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
-        <jackson.version>2.11.4</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
         <jansi.version>1.18</jansi.version>
         <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

ODP-4672 : Upgrade com.fasterxml.jackson.core_jackson-databind to 2.16.1 for CVE
