### PR TITLE
OSV-21272: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <metrics.version>4.2.32</metrics.version>
         <mina.version>2.0.28</mina.version>
         <mockito.version>4.8.1</mockito.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <jakarta.mail.version>1.6.8</jakarta.mail.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <nodejs.version>v14.15.0</nodejs.version>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (1)
OSV-21272
