### PR TITLE
OSV-21303 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34478

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
         <libpam4j.version>1.11</libpam4j.version>
-        <log4j2.version>2.25.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-21303, OSV-21304, OSV-21305, OSV-21306, OSV-21307