### PR TITLE
OSV-21280 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <commons-digester3.version>3.2</commons-digester3.version>
         <commons-io.version>2.8.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-net.version>3.9.0</commons-net.version>


### PR DESCRIPTION
- Component: knox (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-lang3 → 3.18.0
- Tickets: OSV-21280
- Files: pom.xml