### PR TITLE
OSV-21279 - CVE - Bumped-up postgresql to 42.7.11 to address CVE-2026-42198

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <okhttp.version>2.7.5</okhttp.version>
         <opensaml.version>3.4.5</opensaml.version>
         <pac4j.version>4.5.6</pac4j.version>
-        <postgresql.version>42.4.4</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <mysql.version>8.0.28</mysql.version>
         <protobuf.version>3.25.5</protobuf.version>
         <powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
- Component: knox (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: postgresql → 42.7.11
- Tickets: OSV-21279
- Files: pom.xml