### PR TITLE
OSV-21311 - CVE - Bumped-up mina-core to 2.0.28 to address CVE-2026-41409/CVE-2026-41635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
         <metrics.version>4.2.32</metrics.version>
-        <mina.version>2.0.27</mina.version>
+        <mina.version>2.0.28</mina.version>
         <mockito.version>4.8.1</mockito.version>
         <netty.version>4.1.132.Final</netty.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>


### PR DESCRIPTION
- Component: knox (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: mina-core → 2.0.28
- Tickets: OSV-21311, OSV-21312
- Files: pom.xml