### PR TITLE
OSV-21308 - CVE - Bumped-up jakarta.mail to 1.6.8 to address CVE-2025-7962

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,7 @@
         <mina.version>2.0.27</mina.version>
         <mockito.version>4.8.1</mockito.version>
         <netty.version>4.1.132.Final</netty.version>
+        <jakarta.mail.version>1.6.8</jakarta.mail.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <nodejs.version>v14.15.0</nodejs.version>
         <okhttp.version>2.7.5</okhttp.version>
@@ -2722,7 +2723,13 @@
                 <version>${jakarta.activation.version}</version>
                 <scope>runtime</scope>
             </dependency>
-        </dependencies>
+        
+                <dependency>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>jakarta.mail</artifactId>
+                    <version>${jakarta.mail.version}</version>
+                </dependency>
+</dependencies>
     </dependencyManagement>
 
     <dependencies>


### PR DESCRIPTION
- Component: knox (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: jakarta.mail → 1.6.8
- Tickets: OSV-21308
- Files: pom.xml