### PR TITLE
OSV-21274 - CVE - Bumped-up Spring Framework to 5.3.39 to address CVE-2024-38808/CVE-2024-38809

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs.version>4.2.0</spotbugs.version>
         <spotbugs-maven-plugin.version>4.1.4</spotbugs-maven-plugin.version>
-        <spring.version>5.3.34</spring.version>
+        <spring.version>5.3.39</spring.version>
         <spring-vault.version>2.3.3</spring-vault.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>


### PR DESCRIPTION
- Component: knox (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Spring Framework → 5.3.39
- Tickets: OSV-21274, OSV-21287, OSV-21288, OSV-21297
- Files: pom.xml